### PR TITLE
Trim fix

### DIFF
--- a/cmd/kubectl-tap/tap.go
+++ b/cmd/kubectl-tap/tap.go
@@ -452,7 +452,7 @@ func NewTapCommand(client kubernetes.Interface, config *rest.Config, viper *vipe
 			&url.URL{
 				Scheme: "https",
 				Path:   path,
-				Host:   strings.TrimLeft(config.Host, `htps:/`),
+				Host:   strings.TrimPrefix(strings.TrimPrefix(config.Host, `http://`), `https://`),
 			},
 		)
 		fw, err := portforward.New(dialer,


### PR DESCRIPTION
Fix the overzealous trim which also removed matching characters from the domain names:
"https://test-cluster" became "est-cluster"

(also thanks for the great tool !)

Signed-off-by: Alex Ivkin <alexivkin@users.noreply.github.com>