### PR TITLE
add support for m1 macs

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,8 +23,6 @@ builds:
     - goos: darwin
       goarch: 386
     - goos: darwin
-      goarch: arm64
-    - goos: darwin
       goarch: arm
     - goos: windows
       goarch: 386


### PR DESCRIPTION
To support M1 we need to also build for the `arm64` architecture.

I have tested building the golang binary locally and it works great on M1